### PR TITLE
Fixing error when building for production.

### DIFF
--- a/src/core/src/directives/keyboard.directive.ts
+++ b/src/core/src/directives/keyboard.directive.ts
@@ -37,7 +37,7 @@ export class MatKeyboardDirective implements OnDestroy {
   }
 
   @HostListener('focus', ['$event'])
-  private _showKeyboard() {
+  public showKeyboard() {
     this._keyboardRef = this._keyboardService.open(this.matKeyboard, {
       darkTheme: this.darkTheme,
       duration: this.duration,
@@ -60,7 +60,7 @@ export class MatKeyboardDirective implements OnDestroy {
   }
 
   @HostListener('blur', ['$event'])
-  private _hideKeyboard() {
+  public hideKeyboard() {
     if (this._keyboardRef) {
       this._keyboardRef.dismiss();
     }


### PR DESCRIPTION
Building for production (ng build --prod) with last version of Angular causes these errors:

Directive MatKeyboardDirective, Property '_showKeyboard' is private and only accessible within class 'MatKeyboardDirective'. Directive MatKeyboardDirective, Property '_hideKeyboard' is private and only accessible within class 'MatKeyboardDirective'.