### PR TITLE
Adding Ionic support

### DIFF
--- a/src/core/src/components/keyboard-key/keyboard-key.component.ts
+++ b/src/core/src/components/keyboard-key/keyboard-key.component.ts
@@ -344,14 +344,14 @@ export class MatKeyboardKeyComponent implements OnInit, OnDestroy {
 
   private replaceSelectedText(char: string): void {
     const value = this.inputValue ? this.inputValue.toString() : '';
+    const selectionLength = this._getSelectionLength();
 
     let el = this._getInputElement();
-    if (el && 'maxLength' in el && value.length + char.length > el.maxLength) {
+    if (el && 'maxLength' in el && value.length - selectionLength + char.length > el.maxLength) {
       return;
     }
 
     const caret = this.input ? this._getCursorPosition() : 0;
-    const selectionLength = this._getSelectionLength();
     const headPart = value.slice(0, caret);
     const endPart = value.slice(caret + selectionLength);
     this._getInputElement().setRangeText(char, caret, caret + selectionLength);

--- a/src/core/src/components/keyboard-key/keyboard-key.component.ts
+++ b/src/core/src/components/keyboard-key/keyboard-key.component.ts
@@ -347,7 +347,7 @@ export class MatKeyboardKeyComponent implements OnInit, OnDestroy {
     const selectionLength = this._getSelectionLength();
 
     let el = this._getInputElement();
-    if (el && 'maxLength' in el && value.length - selectionLength + char.length > el.maxLength) {
+    if (el && 'maxLength' in el && el.maxLength > 0 && value.length - selectionLength + char.length > el.maxLength) {
       return;
     }
 

--- a/src/core/src/directives/keyboard.directive.ts
+++ b/src/core/src/directives/keyboard.directive.ts
@@ -6,7 +6,7 @@ import { MatKeyboardComponent } from '../components/keyboard/keyboard.component'
 import { MatKeyboardService } from '../services/keyboard.service';
 
 @Directive({
-  selector: 'input[matKeyboard], textarea[matKeyboard]'
+  selector: 'ion-input[matKeyboard], ion-textarea[matKeyboard], input[matKeyboard], textarea[matKeyboard]'
 })
 export class MatKeyboardDirective implements OnDestroy {
 
@@ -37,6 +37,7 @@ export class MatKeyboardDirective implements OnDestroy {
   }
 
   @HostListener('focus', ['$event'])
+  @HostListener('ionFocus', ['$event'])
   public showKeyboard() {
     this._keyboardRef = this._keyboardService.open(this.matKeyboard, {
       darkTheme: this.darkTheme,
@@ -60,6 +61,7 @@ export class MatKeyboardDirective implements OnDestroy {
   }
 
   @HostListener('blur', ['$event'])
+  @HostListener('ionBlur', ['$event'])
   public hideKeyboard() {
     if (this._keyboardRef) {
       this._keyboardRef.dismiss();


### PR DESCRIPTION
The PR adds support to Ionic.
As Ionic uses different events for its input components (ionBlur, ionFocus, etc.) and obviously because of the "middle man issue" (e.g. Ionic sets between the keyboard component and the final HTMLInputElement) the following changes had to be done:
a.) Add support for Ionic's events in MatKeyboardDirective
b.) Generalize HTMLInputElement handling via getting the appropriate attribute from the element using matKeyboard
(e.g. use either this.input.nativeElement ('normal case') or this.input.nativeElement.firstChild ('ionic case')